### PR TITLE
Better planner UX

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -20,18 +20,17 @@
             "tsConfig": "tsconfig.app.json",
             "aot": true,
             "assets": ["src/favicon.ico", "src/assets"],
-            "styles": [
-              "src/theme.scss",
-              "src/styles.css"
-            ],
+            "styles": ["src/theme.scss", "src/styles.css"],
             "scripts": []
           },
           "configurations": {
             "production": {
-              "fileReplacements": [{
-                "replace": "src/environments/environment.ts",
-                "with": "src/environments/environment.prod.ts"
-              }],
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
+              ],
               "optimization": true,
               "outputHashing": "all",
               "sourceMap": false,
@@ -40,7 +39,8 @@
               "extractLicenses": true,
               "vendorChunk": false,
               "buildOptimizer": true,
-              "budgets": [{
+              "budgets": [
+                {
                   "type": "initial",
                   "maximumWarning": "2mb",
                   "maximumError": "5mb"
@@ -72,12 +72,14 @@
         },
         "test": {
           "builder": "@angular-devkit/build-angular:karma",
+
           "options": {
             "main": "src/test.ts",
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
             "assets": ["src/favicon.ico", "src/assets"],
+            "codeCoverageExclude": ["**/*.fake.ts"],
             "styles": [
               "./node_modules/@angular/material/prebuilt-themes/deeppurple-amber.css",
               "src/styles.css"

--- a/src/app/error/transform-error.spec.ts
+++ b/src/app/error/transform-error.spec.ts
@@ -1,0 +1,87 @@
+import { HttpErrorResponse, HttpHeaders } from '@angular/common/http'
+import { of, throwError } from 'rxjs'
+import { catchError, tap } from 'rxjs/operators'
+
+import { transformError } from './transform-error'
+
+describe('transformError', () => {
+  it('returns the provided error if string', done => {
+    // tslint:disable-next-line: no-string-throw
+    throwError('Test error message')
+      .pipe(
+        catchError(transformError),
+        tap({
+          // Fail test if we don't see the error
+          next: () => expect(true).toBe(false),
+          // Check the error message is formatted as expected
+          error: msg => expect(msg).toBe('Test error message'),
+        }),
+        // mask the error so Jest doesn't have a false positive
+        catchError(() => {
+          done()
+          return of()
+        })
+      )
+      .subscribe()
+  })
+
+  it('returns the provided error if string', done => {
+    // tslint:disable-next-line: no-string-throw
+    throwError({ error: new ErrorEvent('', { message: 'Event error message' }) })
+      .pipe(
+        catchError(transformError),
+        tap({
+          // Fail test if we don't see the error
+          next: () => expect(true).toBe(false),
+          // Check the error message is formatted as expected
+          error: msg => expect(msg).toBe('Error! Event error message'),
+        }),
+        // mask the error so Jest doesn't have a false positive
+        catchError(() => {
+          done()
+          return of()
+        })
+      )
+      .subscribe()
+  })
+
+  it('returns the provided error if string', done => {
+    // tslint:disable-next-line: no-string-throw
+    throwError(new HttpErrorResponse({ status: 404, statusText: 'Status error message' }))
+      .pipe(
+        catchError(transformError),
+        tap({
+          // Fail test if we don't see the error
+          next: () => expect(true).toBe(false),
+          // Check the error message is formatted as expected
+          error: msg => expect(msg).toBe('Request failed with 404 Status error message'),
+        }),
+        // mask the error so Jest doesn't have a false positive
+        catchError(() => {
+          done()
+          return of()
+        })
+      )
+      .subscribe()
+  })
+
+  it('returns the default error if string', done => {
+    // tslint:disable-next-line: no-string-throw
+    throwError(null)
+      .pipe(
+        catchError(transformError),
+        tap({
+          // Fail test if we don't see the error
+          next: () => expect(true).toBe(false),
+          // Check the error message is formatted as expected
+          error: msg => expect(msg).toBe('An unknown error has occurred'),
+        }),
+        // mask the error so Jest doesn't have a false positive
+        catchError(() => {
+          done()
+          return of()
+        })
+      )
+      .subscribe()
+  })
+})

--- a/src/app/error/transform-error.ts
+++ b/src/app/error/transform-error.ts
@@ -5,9 +5,9 @@ export function transformError(error: HttpErrorResponse | string) {
   let errorMessage = 'An unknown error has occurred'
   if (typeof error === 'string') {
     errorMessage = error
-  } else if (error.error instanceof ErrorEvent) {
+  } else if (error?.error instanceof ErrorEvent) {
     errorMessage = `Error! ${error.error.message}`
-  } else if (error.status) {
+  } else if (error?.status) {
     errorMessage = `Request failed with ${error.status} ${error.statusText}`
   } else if (error instanceof Error) {
     errorMessage = error.message

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -6,7 +6,7 @@
       <a mat-list-item routerLink="/planner/overview" routerLinkActive="active">Plan Overview</a>
       <mat-divider></mat-divider>
       <!-- <a mat-list-item routerLink="/bio" routerLinkActive="active">Xpert Bio</a> -->
-      <a mat-list-item routerLink="/planner/plan" routerLinkActive="active">Xpert Plan</a>
+      <a mat-list-item routerLink="/planner/plan" routerLinkActive="active">My Xpert Plan</a>
       <mat-divider></mat-divider>
       <a mat-list-item routerLink="/planner/export" routerLinkActive="active">Export Plan</a>
       <a mat-list-item routerLink="/planner/import" routerLinkActive="active">Import Plan</a>

--- a/src/app/material.module.ts
+++ b/src/app/material.module.ts
@@ -13,11 +13,11 @@ import { MatInputModule } from '@angular/material/input'
 import { MatListModule } from '@angular/material/list'
 import { MatSelectModule } from '@angular/material/select'
 import { MatSidenavModule } from '@angular/material/sidenav'
-import { MatSlideToggleModule } from '@angular/material/slide-toggle'
 import { MatSnackBarModule } from '@angular/material/snack-bar'
 import { MatSortModule } from '@angular/material/sort'
 import { MatTableModule } from '@angular/material/table'
 import { MatToolbarModule } from '@angular/material/toolbar'
+import { MatTooltipModule } from '@angular/material/tooltip'
 
 const materialModules = [
   LayoutModule,
@@ -34,11 +34,11 @@ const materialModules = [
   MatListModule,
   MatSelectModule,
   MatSidenavModule,
-  MatSlideToggleModule,
   MatSnackBarModule,
   MatSortModule,
   MatTableModule,
   MatToolbarModule,
+  MatTooltipModule,
 ]
 
 @NgModule({

--- a/src/app/planner/pipes/tooltip-list/tooltip-list.pipe.spec.ts
+++ b/src/app/planner/pipes/tooltip-list/tooltip-list.pipe.spec.ts
@@ -1,0 +1,25 @@
+import { TooltipListPipe } from './tooltip-list.pipe'
+
+describe('ToolTipPipe', () => {
+  describe('transform', () => {
+    let items: string[]
+    let pipe: TooltipListPipe
+
+    beforeEach(() => {
+      items = ['Thing 1', 'Thing 2', 'Thing 3']
+      pipe = new TooltipListPipe()
+    })
+
+    it('should add bullet-points to each item', () => {
+      const result = pipe.transform(items)
+      const prefix = '• '
+      items.forEach(i => expect(result).toContain(`${prefix}${i}`))
+    })
+
+    it('should add a newline to each item', () => {
+      const result = pipe.transform(items)
+      const suffix = '\n'
+      items.forEach(i => expect(result).toContain(`${i}${suffix}`))
+    })
+  })
+})

--- a/src/app/planner/pipes/tooltip-list/tooltip-list.pipe.ts
+++ b/src/app/planner/pipes/tooltip-list/tooltip-list.pipe.ts
@@ -1,0 +1,9 @@
+import { Pipe, PipeTransform } from '@angular/core'
+
+// Taken from: https://stackoverflow.com/questions/53197606/is-it-possible-to-have-a-list-inside-of-an-angular-material-tooltip
+@Pipe({ name: 'tooltipList' })
+export class TooltipListPipe implements PipeTransform {
+  transform(items: string[]): string {
+    return items.map(i => `• ${i}\n`).join('')
+  }
+}

--- a/src/app/planner/plan/item-form/item-form.component.ts
+++ b/src/app/planner/plan/item-form/item-form.component.ts
@@ -82,7 +82,7 @@ export class ItemFormComponent extends AbstractFormComponent<IPlanItem>
   }
 
   compareBaseItems(itemA: IBasePlanItem, itemB: IBasePlanItem) {
-    return itemA.id === itemB.id
+    return itemA?.id === itemB?.id
   }
 
   /*  GETTERS  */

--- a/src/app/planner/plan/plan.component.css
+++ b/src/app/planner/plan/plan.component.css
@@ -9,3 +9,7 @@
 .with-margin-bottom-15 {
   margin-bottom: 15px;
 }
+
+.invalid-category {
+  border: 1px solid red;
+}

--- a/src/app/planner/plan/plan.component.html
+++ b/src/app/planner/plan/plan.component.html
@@ -1,14 +1,16 @@
 <mat-card class="with-margin-30">
   <mat-card-header class="with-margin-bottom-15" fxLayoutAlign="end center">
     <div>
-      <mat-slide-toggle (change)="editMode$.next($event.checked)" labelPosition="before" fxFlex>Edit</mat-slide-toggle>
+      <mat-checkbox (change)="displayMode$.next($event.checked)" labelPosition="before" fxFlex>Display Mode
+      </mat-checkbox>
     </div>
   </mat-card-header>
-  <ng-container *ngIf="(editMode$ | async) else display">
+  <ng-container *ngIf="!(displayMode$ | async) else display">
     <mat-card-content fxLayout="column" fxLayoutGap="10px">
       <mat-accordion [multi]="true">
-        <mat-expansion-panel *ngFor="let category of categories$ | async; let i = index">
-          <mat-expansion-panel-header class="right-aligned-header">
+        <mat-expansion-panel *ngFor="let category of categories$ | async; let i = index" #panel>
+          <mat-expansion-panel-header class="right-aligned-header"
+            [ngClass]="{'invalid-category': plan?.at(i)?.invalid && plan?.at(i)?.touched && !panel.expanded}">
             <mat-panel-title>{{ category.name }}</mat-panel-title>
             <mat-panel-description>{{ getPointsDisplayByIndex(i) | async }}</mat-panel-description>
           </mat-expansion-panel-header>
@@ -18,8 +20,12 @@
           </app-item-list>
         </mat-expansion-panel>
       </mat-accordion>
-      <div fxFlex>
-        <button mat-raised-button color="accent" (click)="onSave()" fxFlexAlign="end">Save</button>
+      <div fxFlex fxLayoutAlign="start center">
+        <button mat-raised-button color="accent" (click)="onSave()" fxFlexAlign="end" fxShrink>Save</button>
+        <mat-icon fxShrink [color]="plan.invalid ? 'warn' : 'primary'"
+          [matTooltip]="['Each category has 1+ item', 'Each item has Type, Description and Points'] | tooltipList"
+          matTooltipClass="tooltip-list">help
+        </mat-icon>
       </div>
     </mat-card-content>
     <mat-card-footer class="with-margin-left-30">

--- a/src/app/planner/plan/plan.component.spec.ts
+++ b/src/app/planner/plan/plan.component.spec.ts
@@ -9,6 +9,7 @@ import { MaterialModule } from '../../material.module'
 import { SnackBarService } from '../../messaging/services/snack-bar/snack-bar.service'
 import { baseItems, categories, plan } from '../models/mock.data'
 import { IPlanItem } from '../models/xpert-plan.interface'
+import { TooltipListPipe } from '../pipes/tooltip-list/tooltip-list.pipe'
 import { BaseItemService } from '../services/base-item/base-item.service'
 import { CategoryService } from '../services/category/category.service'
 import { PlanService } from '../services/plan/plan.service'
@@ -44,12 +45,14 @@ describe('PlanComponent', () => {
         ItemListComponent,
         CompletedTableComponent,
         ForecastedTableComponent,
+        TooltipListPipe,
       ],
       providers: [
         { provide: CategoryService, useValue: categoryService },
         { provide: PlanService, useValue: planService },
         { provide: BaseItemService, useValue: baseItemService },
         SnackBarService,
+        TooltipListPipe,
       ],
     }).compileComponents()
   }))
@@ -65,15 +68,15 @@ describe('PlanComponent', () => {
   })
 
   // This is such a cheat
-  it('should work in editMode', async () => {
-    component.editMode$.next(true)
+  it('should work in displayMode', async () => {
+    component.displayMode$.next(true)
     await fixture.detectChanges()
     expect(component).toBeTruthy()
   })
 
   describe('onSave()', () => {
     beforeEach(async () => {
-      component.editMode$.next(true)
+      component.displayMode$.next(true)
       await fixture.detectChanges()
     })
     it('should call PlanService.setPlan', () => {

--- a/src/app/planner/plan/plan.component.ts
+++ b/src/app/planner/plan/plan.component.ts
@@ -1,10 +1,11 @@
 import { Component, OnDestroy, OnInit } from '@angular/core'
 import { AbstractControl, FormArray, FormBuilder, FormGroup } from '@angular/forms'
 import { BehaviorSubject, Observable } from 'rxjs'
-import { map, take } from 'rxjs/operators'
+import { map, take, tap } from 'rxjs/operators'
 
 import { AbstractFormComponent } from '../../abstracts/abstract-form/abstract-form.component'
 import { SnackBarService } from '../../messaging/services/snack-bar/snack-bar.service'
+import { plan } from '../models/mock.data'
 import { ICategory, IPlanItem } from '../models/xpert-plan.interface'
 import { CategoryService } from '../services/category/category.service'
 import { PlanService } from '../services/plan/plan.service'
@@ -31,7 +32,7 @@ export class PlanComponent extends AbstractFormComponent<any>
   totalEarnedPastSixMonths$: Observable<number>
   totalEarnedPastYear$: Observable<number>
 
-  editMode$ = new BehaviorSubject<boolean>(false)
+  displayMode$ = new BehaviorSubject<boolean>(false)
 
   constructor(
     private formBuilder: FormBuilder,
@@ -104,6 +105,7 @@ export class PlanComponent extends AbstractFormComponent<any>
 
   onSave(): boolean {
     if (this.formGroup.invalid) {
+      this.formGroup.markAllAsTouched()
       this.snackBarService.openSnackBar('Unable to save, invalid data!')
       return false
     }

--- a/src/app/planner/planner.module.ts
+++ b/src/app/planner/planner.module.ts
@@ -12,6 +12,7 @@ import { MaterialModule } from '../material.module'
 import { ExportPlanComponent } from './export-plan/export-plan.component'
 import { ImportPlanComponent } from './import-plan/import-plan.component'
 import { OverviewComponent } from './overview/overview.component'
+import { TooltipListPipe } from './pipes/tooltip-list/tooltip-list.pipe'
 import { CompletedTableComponent } from './plan/completed-table/completed-table.component'
 import { ForecastedTableComponent } from './plan/forecasted-table/forecasted-table.component'
 import { ItemFormComponent } from './plan/item-form/item-form.component'
@@ -34,6 +35,7 @@ import { PlanService } from './services/plan/plan.service'
     OverviewComponent,
     CompletedTableComponent,
     ForecastedTableComponent,
+    TooltipListPipe,
   ],
   imports: [
     ChartsModule,
@@ -58,6 +60,7 @@ import { PlanService } from './services/plan/plan.service'
       deps: [HttpClient, AngularFireFunctions],
     },
     PlanService,
+    TooltipListPipe,
   ],
 })
 export class PlannerModule {}

--- a/src/app/planner/services/plan/plan.service.ts
+++ b/src/app/planner/services/plan/plan.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core'
 import { BehaviorSubject, Observable } from 'rxjs'
-import { IPlanItem } from 'src/app/planner/models/xpert-plan.interface'
+
+import { IPlanItem } from '../../models/xpert-plan.interface'
 
 @Injectable()
 export class PlanService {

--- a/src/app/user/user.spec.ts
+++ b/src/app/user/user.spec.ts
@@ -1,0 +1,77 @@
+import { Role } from '../auth/auth.enum'
+import { IUser, User } from './user'
+
+describe('User', () => {
+  describe('.Build', () => {
+    it('returns the default if provided null', () => {
+      const user = User.Build(null)
+      expect(user._id).toBe('')
+      expect(user.email).toBe('')
+      expect(user.name).toEqual({ first: '', middle: '', last: '' })
+    })
+
+    it('converts the date of birth if a string', () => {
+      const user = User.Build({ dateOfBirth: '01/15/2000' } as IUser)
+      expect(user.dateOfBirth).toEqual(new Date('01/15/2000'))
+    })
+  })
+
+  describe('fullname', () => {
+    let user: User
+    beforeEach(() => {
+      user = new User()
+    })
+    it('returns null if name is null', () => {
+      user.name = null
+      expect(user.fullName).toBeNull()
+    })
+    it('excludes the middle name if it is falsy', () => {
+      user.name = { first: 'First', middle: null, last: 'Last' }
+      expect(user.fullName).toBe('First Last')
+    })
+    it('uses all three names', () => {
+      user.name = { first: 'First', middle: 'Middle', last: 'Last' }
+      expect(user.fullName).toBe('First Middle Last')
+    })
+  })
+
+  describe('toJSON', () => {
+    it('serializes without _id or fullname', () => {
+      const dob = new Date()
+      const user = new User(
+        'UUID-1234',
+        'user@email.com',
+        {
+          first: 'First',
+          middle: 'Middle',
+          last: 'Last',
+        },
+        'http://image.url',
+        Role.User,
+        dob,
+        true,
+        5,
+        {
+          line1: '123 Main st',
+          city: 'Anytown',
+          state: 'VA',
+          zip: '12345',
+        },
+        ['(223)-555-1234', '(334)-666-9876']
+      )
+      const result = {
+        email: 'user@email.com',
+        name: { first: 'First', middle: 'Middle', last: 'Last' },
+        picture: 'http://image.url',
+        role: 'User',
+        dateOfBirth: dob.toJSON(),
+        userStatus: true,
+        level: 5,
+        address: { line1: '123 Main st', city: 'Anytown', state: 'VA', zip: '12345' },
+        phones: ['(223)-555-1234', '(334)-666-9876'],
+      }
+      // stringify to obscure Object.assign weirdness
+      expect(JSON.stringify(user.toJSON())).toEqual(JSON.stringify(result))
+    })
+  })
+})

--- a/src/styles.css
+++ b/src/styles.css
@@ -22,3 +22,7 @@ body {
 .solo-mat-card {
   margin: 10px;
 }
+
+.tooltip-list {
+  white-space: pre;
+}


### PR DESCRIPTION
Resolves #28 by upgrading the UX for users.

- Sets planner to Edit mode by default
- Swaps "Edit" slide toggle to "Display" checkbox
- Adds a help icon+tooltip by the Save button
- Better error surfacing when trying to save an invalid plan
- Clearer purpose for nav link ("Xpert Plan" -> "My Xpert Plan")